### PR TITLE
Basic layers for alexnet added in core/config.yaml

### DIFF
--- a/core/config.yaml
+++ b/core/config.yaml
@@ -14,7 +14,7 @@ layers:
       - top
 
   - LinearLayer:
-     - weights
+      - weights
       - biases
       - dim:
         - neurons

--- a/core/config.yaml
+++ b/core/config.yaml
@@ -24,3 +24,40 @@ layers:
       - name
       - bottom
       - top
+
+  - ReLULayer:
+      - name
+      - bottom
+      - top
+      - negative_slope
+
+  - PoolingLayer:
+    - name
+    - bottom
+    - top
+    - padding
+    - stride
+    - kernel_size
+    - pool 
+
+  - LRNLayer:
+    - name
+    - bottom
+    - top
+    - local_size
+    - alpha
+    - beta
+    - norm_region
+    - k
+
+  - DropoutLayer:
+    - name
+    - bottom
+    - top
+    - dropout_ratio
+
+  - SoftmaxLayer:
+    - name
+    - bottom
+    - top
+    - axis


### PR DESCRIPTION
For now these are the layers available for our intermediate format, and their configuration options.

I have set dimensions only for those layers that will have trainable parameters, i.e convolution and linear.
