### PR TITLE
Each layer in core/config.py is now a dict entry

### DIFF
--- a/core/config.yaml
+++ b/core/config.yaml
@@ -1,37 +1,37 @@
 layers:
-  - ConvolutionLayer:
-      - weights
-      - biases
-      - dim:
-        - neurons
-        - channels
-        - height
-        - width
-      - name
-      - padding
-      - stride
-      - bottom
-      - top
+  ConvolutionLayer:
+    - weights
+    - biases
+    - dim:
+      - neurons
+      - channels
+      - height
+      - width
+    - name
+    - padding
+    - stride
+    - bottom
+    - top
 
-  - LinearLayer:
-      - weights
-      - biases
-      - dim:
-        - neurons
-        - channels
-        - height
-        - width
-      - name
-      - bottom
-      - top
+  LinearLayer:
+    - weights
+    - biases
+    - dim:
+      - neurons
+      - channels
+      - height
+      - width
+    - name
+    - bottom
+    - top
 
-  - ReLULayer:
-      - name
-      - bottom
-      - top
-      - negative_slope
+  ReLULayer:
+    - name
+    - bottom
+    - top
+    - negative_slope
 
-  - PoolingLayer:
+  PoolingLayer:
     - name
     - bottom
     - top
@@ -40,7 +40,7 @@ layers:
     - kernel_size
     - pool 
 
-  - LRNLayer:
+  LRNLayer:
     - name
     - bottom
     - top
@@ -50,14 +50,21 @@ layers:
     - norm_region
     - k
 
-  - DropoutLayer:
+  DropoutLayer:
     - name
     - bottom
     - top
     - dropout_ratio
 
-  - SoftmaxLayer:
+  SoftmaxLayer:
     - name
     - bottom
     - top
     - axis
+
+  ConcatLayer:
+    - name
+    - bottom
+    - top
+    - axis
+    - concat_dim


### PR DESCRIPTION
Each layer in core/config.py is now a dict entry, instead of an element of a list.

Before, the yaml would be loaded as a dictionary with one key 'layers' that mapped to a list of dictionaries with only one key. For example, one would index Convolution layer by: foo['layers'][0]['ConvolutionLayer'].

This is not practical, so I changed the yaml format so that now it gets accessed like: foo['layers']['ConvolutionLayer']
